### PR TITLE
User password hashes for validation

### DIFF
--- a/createUser.js
+++ b/createUser.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const bcrypt = require('bcrypt');
+const readline = require('readline');
+
+users = require('./users.json');
+
+
+const consoleIn  = readline.createInterface(process.stdin, process.stdout);
+
+function main() {
+    consoleIn.question('Enter a username: ', (name) => {
+        consoleIn.question('Enter the password: ', (password) => {
+            setUserPassword(name, password);
+            consoleIn.close();
+        });
+    });
+}
+
+function setUserPassword(name, password) {
+    hash = bcrypt.hashSync(password, 8);
+    users[name] = hash;
+    console.log('Added: ', name, ' with hash ', hash);
+    saveFile();
+}
+
+function saveFile() {
+    fs.writeFile('./users.json', JSON.stringify(users), 'utf8', 
+        function(error) {
+            if (error) throw error;
+            console.log('Saved to users.json!');
+    });
+}
+
+main();

--- a/example-password-valid.js
+++ b/example-password-valid.js
@@ -1,0 +1,9 @@
+const bcrypt = require('bcrypt');
+
+users = require('./users.json');
+
+console.log("trying 'admin' + 'bar'");
+console.log(bcrypt.compareSync("bar", users["admin"]));
+
+console.log("trying 'admin' + 'foo'");
+console.log(bcrypt.compareSync("foo", users["admin"]));

--- a/modules/users.js
+++ b/modules/users.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const bcrypt = require('bcrypt');
 
 module.exports = class users {
     constructor () {
@@ -13,6 +14,7 @@ module.exports = class users {
         if (global.debug) {
             console.log('DEBUG: testing user ' + username);
         }
-        return (this.users[username] === pass);
+        //Better: Asynchronous. Server thread is blocked for some millis with this.
+        return bcrypt.compareSync(pass, this.users[username]);
     }
 }

--- a/transferUserPasswordsToHashes.js
+++ b/transferUserPasswordsToHashes.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const bcrypt = require('bcrypt');
+
+users = require('./users.json');
+Object.keys(users).forEach(function(user) {
+    users[user] = bcrypt.hashSync(users[user], 8);
+});
+
+fs.writeFile('./users.json', JSON.stringify(users), 'utf8', 
+        function(error) {
+            if (error) throw error;
+            console.log('convertion completed');
+        });


### PR DESCRIPTION
Plain text saving of passwords is simply bad.
This is an example of how you can use hashes for validation.